### PR TITLE
Remove --non-zero-exit-on-violation option for PhpMnd

### DIFF
--- a/src/Task/PhpMnd.php
+++ b/src/Task/PhpMnd.php
@@ -92,7 +92,6 @@ class PhpMnd extends AbstractExternalTask
         $arguments->addOptionalCommaSeparatedArgument('--ignore-strings=%s', $config['ignore_strings']);
         $arguments->addOptionalArgument('--strings', $config['strings']);
         $arguments->addOptionalCommaSeparatedArgument('--suffixes=%s', $config['triggered_by']);
-        $arguments->add('--non-zero-exit-on-violation');
         $arguments->add($config['directory']);
 
         $process = $this->processBuilder->buildProcess($arguments);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Documented?   | no
| Fixed tickets | #990

In the master version of PhpMnd the `--non-zero-exit-on-violation` option was removed. This PR removes this option from the arguments list.